### PR TITLE
feat: add annotation layer that renders above hover/selection (#7)

### DIFF
--- a/COMMUNICATION.div.upstream-fixes-issue-7-10.md
+++ b/COMMUNICATION.div.upstream-fixes-issue-7-10.md
@@ -13,19 +13,25 @@
 - `_render_map.py`: Added `resolve_id()` for registry lookup
 - Added `app_module.py` example to test module namespacing
 
-### Issue #7 - NOT STARTED
+### Issue #7 - READY FOR REVIEW
 **Feature**: Add 'annotation' layer that renders above hover/selection layers
 
 **Problem**: Overlay regions (including those added via `glaze()`) render below selection/hover layers. Text labels get covered when regions are selected or hovered.
 
-**Current layer order**:
-1. Underlay
-2. Base (interactive)
-3. Overlay
-4. Selection layer
-5. Hover layer
+**Changes**:
+- `layers.ts`: Added `annotation` to `LayerAssignment` type and `assignLayers()` function
+- `types.ts`: Added `annotation` to `LayersConfig` type
+- `InputMap.tsx`: Added Layer 6 annotation rendering after hover layer
+- `OutputMap.tsx`: Added Layer 6 annotation rendering after hover layer
+- `_outline.py`: Added `annotation_ids()`, updated `layers_dict()`, `merge_layers()`, and `move_layer()`
+- `app_annotation.py`: Demo app comparing annotation vs overlay layer behavior
 
-**Desired layer order**:
+**Demo app**: `packages/shinymap/python/examples/app_annotation.py`
+```bash
+cd packages/shinymap/python/examples && uv run shiny run app_annotation.py
+```
+
+**Rendering order** (SVG stacking - later = on top):
 1. Underlay
 2. Base (interactive)
 3. Overlay
@@ -33,21 +39,72 @@
 5. Hover layer
 6. **Annotation layer** (new - always on top)
 
-**Files to modify**:
-- `packages/shinymap/js/src/utils/layers.ts` - Add annotation to LayerAssignment
-- `packages/shinymap/js/src/components/InputMap.tsx` - Add Layer 6 rendering
-- `packages/shinymap/js/src/components/OutputMap.tsx` - Add Layer 6 rendering
-- `packages/shinymap/python/src/shinymap/kit/_caption.py` - Add `as_annotation` param to `glaze()`
-- `packages/shinymap/python/src/shinymap/outline/_core.py` - Support annotation in metadata
+## Implementation Plan
 
-## Next Steps
+### TypeScript Changes (4 files)
 
-1. Add "annotation" to `LayerAssignment` type in `layers.ts`
-2. Update `assignLayers()` to handle annotation layer
-3. Add Layer 6 rendering in both React components
-4. Update Python `glaze()` to support `as_annotation=True`
-5. Update `Outline.merge_layers()` to handle annotation layer
-6. Add tests
+1. **`packages/shinymap/js/src/utils/layers.ts`**
+   - Add `annotation: Set<RegionId>` to `LayerAssignment` type (line 45-50)
+   - Update `assignLayers()` to accept `annotation` parameter
+   - Add annotation to the if-else assignment chain (after hidden, before overlay)
+
+2. **`packages/shinymap/js/src/types.ts`**
+   - Add `annotation?: string[]` to `LayersConfig` type (lines 680-688)
+
+3. **`packages/shinymap/js/src/components/InputMap.tsx`**
+   - Extract `annotation` from layers config
+   - Pass `annotation` to `assignLayers()` call
+   - Add Layer 6 rendering after hover layer
+
+4. **`packages/shinymap/js/src/components/OutputMap.tsx`**
+   - Extract `annotation` from layers config
+   - Pass `annotation` to `assignLayers()` call
+   - Add Layer 6 rendering after hover layer
+
+### Python Changes (1 file)
+
+5. **`packages/shinymap/python/src/shinymap/outline/_outline.py`**
+   - Add `annotation_ids()` method (similar to `overlay_ids()`)
+   - Update `layers_dict()` to include "annotation" key
+   - Update `move_layer()` to accept "annotation" as valid layer
+
+### Key Details
+
+**Assignment logic in assignLayers()** - each region goes to exactly one layer:
+```typescript
+if (hiddenRegions.has(id)) {
+  result.hidden.add(id);        // hidden wins (don't render)
+} else if (annotationRegions.has(id)) {
+  result.annotation.add(id);    // NEW: annotation next
+} else if (overlayRegions.has(id)) {
+  result.overlay.add(id);
+} else if (underlayRegions.has(id)) {
+  result.underlay.add(id);
+} else {
+  result.base.add(id);          // default
+}
+```
+
+**Layer 6 rendering:**
+```tsx
+{/* Layer 6: Annotation - always on top, even above hover */}
+<g>{renderNonInteractiveLayer(layerAssignment.annotation, "annotation")}</g>
+```
+
+### Notes
+- `glaze()` already implemented in task branch (commit fbced42)
+- This diversion adds the annotation layer infrastructure
+- Task branch will rebase onto dev after this diversion merges
+
+## Completed Steps
+
+1. [x] Update `LayerAssignment` type and `assignLayers()` in layers.ts
+2. [x] Add `annotation` to `LayersConfig` in types.ts
+3. [x] Add Layer 6 annotation rendering to InputMap.tsx
+4. [x] Add Layer 6 annotation rendering to OutputMap.tsx
+5. [x] Update Python Outline class (annotation_ids, layers_dict, move_layer)
+6. [x] Run linting, formatting, and tests
+7. [x] Create demo app (app_annotation.py)
 
 ## Commands
 

--- a/packages/shinymap/js/dist/components/InputMap.js
+++ b/packages/shinymap/js/dist/components/InputMap.js
@@ -45,6 +45,7 @@ export function InputMap(props) {
     // Extract from nested layers config
     const underlays = layers === null || layers === void 0 ? void 0 : layers.underlay;
     const overlays = layers === null || layers === void 0 ? void 0 : layers.overlay;
+    const annotations = layers === null || layers === void 0 ? void 0 : layers.annotation;
     const hidden = layers === null || layers === void 0 ? void 0 : layers.hidden;
     // Extract from nested mode config (supports both string shorthand and full config)
     const normalizedMode = typeof modeConfig === "string" ? { type: modeConfig } : modeConfig;
@@ -55,7 +56,7 @@ export function InputMap(props) {
     // Normalize regions to Element[] format (handles both v0.x strings and v1.x polymorphic elements)
     const normalizedRegions = useMemo(() => normalizeRegions(regions), [regions]);
     // New layer system: assign regions to layers
-    const layerAssignment = useMemo(() => assignLayers(normalizedRegions, underlays, overlays, hidden, outlineMetadata), [normalizedRegions, underlays, overlays, hidden, outlineMetadata]);
+    const layerAssignment = useMemo(() => assignLayers(normalizedRegions, underlays, overlays, annotations, hidden, outlineMetadata), [normalizedRegions, underlays, overlays, annotations, hidden, outlineMetadata]);
     const normalizedFillColor = useMemo(() => normalizeFillColor(fillColor, normalizedRegions), [fillColor, normalizedRegions]);
     const [hovered, setHovered] = useState(null);
     // Use internal state for counts, initialized from value prop
@@ -381,5 +382,5 @@ export function InputMap(props) {
                                 pointerEvents: "none",
                             });
                         });
-                    })() })] }));
+                    })() }), _jsx("g", { children: renderNonInteractiveLayer(layerAssignment.annotation, "annotation") })] }));
 }

--- a/packages/shinymap/js/dist/components/OutputMap.js
+++ b/packages/shinymap/js/dist/components/OutputMap.js
@@ -60,11 +60,12 @@ export function OutputMap(props) {
     // Extract from nested layers config
     const underlays = layers === null || layers === void 0 ? void 0 : layers.underlay;
     const overlays = layers === null || layers === void 0 ? void 0 : layers.overlay;
+    const annotations = layers === null || layers === void 0 ? void 0 : layers.annotation;
     const hidden = layers === null || layers === void 0 ? void 0 : layers.hidden;
     // Normalize regions to Element[] format (handles both v0.x strings and v1.x polymorphic elements)
     const normalizedRegions = useMemo(() => normalizeRegions(regions), [regions]);
     // New layer system: assign regions to layers
-    const layerAssignment = useMemo(() => assignLayers(normalizedRegions, underlays, overlays, hidden, outlineMetadata), [normalizedRegions, underlays, overlays, hidden, outlineMetadata]);
+    const layerAssignment = useMemo(() => assignLayers(normalizedRegions, underlays, overlays, annotations, hidden, outlineMetadata), [normalizedRegions, underlays, overlays, annotations, hidden, outlineMetadata]);
     const [hovered, setHovered] = useState(null);
     // Derive active/selected regions from value (value > 0 means selected)
     const activeSet = deriveActiveFromValue(value);
@@ -363,5 +364,5 @@ export function OutputMap(props) {
                                 pointerEvents: "none",
                             });
                         });
-                    })() })] }));
+                    })() }), _jsx("g", { children: renderNonInteractiveLayer(layerAssignment.annotation, "annotation") })] }));
 }

--- a/packages/shinymap/js/dist/types.d.ts
+++ b/packages/shinymap/js/dist/types.d.ts
@@ -367,6 +367,8 @@ export type LayersConfig = {
     underlay?: string[];
     /** Group names to render in overlay layer (above base regions). */
     overlay?: string[];
+    /** Group names to render in annotation layer (above hover/selection, always on top). */
+    annotation?: string[];
     /** Group names to hide completely (not rendered). */
     hidden?: string[];
 };

--- a/packages/shinymap/js/dist/utils/layers.d.ts
+++ b/packages/shinymap/js/dist/utils/layers.d.ts
@@ -20,6 +20,7 @@ export type LayerAssignment = {
     underlay: Set<RegionId>;
     base: Set<RegionId>;
     overlay: Set<RegionId>;
+    annotation: Set<RegionId>;
     hidden: Set<RegionId>;
 };
 /**
@@ -27,20 +28,22 @@ export type LayerAssignment = {
  *
  * Layer priority (highest to lowest):
  * 1. hidden - not rendered at all
- * 2. overlay - rendered above base
- * 3. underlay - rendered below base
- * 4. base - default layer for all other regions
+ * 2. annotation - rendered above hover/selection (always on top)
+ * 3. overlay - rendered above base but below selection/hover
+ * 4. underlay - rendered below base
+ * 5. base - default layer for all other regions
  *
  * A region appears in at most one layer.
  *
  * @param regions - The normalized regions map
  * @param underlay - Group names for underlay layer
  * @param overlay - Group names for overlay layer
+ * @param annotation - Group names for annotation layer (renders above hover)
  * @param hidden - Group names to hide
  * @param metadata - Optional outline metadata
  * @returns Layer assignment for each region
  */
-export declare function assignLayers(regions: Record<RegionId, Element[]>, underlay?: string[], overlay?: string[], hidden?: string[], metadata?: OutlineMetadata): LayerAssignment;
+export declare function assignLayers(regions: Record<RegionId, Element[]>, underlay?: string[], overlay?: string[], annotation?: string[], hidden?: string[], metadata?: OutlineMetadata): LayerAssignment;
 /**
  * Resolves aesthetic for a region based on group membership.
  *

--- a/packages/shinymap/js/dist/utils/layers.js
+++ b/packages/shinymap/js/dist/utils/layers.js
@@ -36,34 +36,41 @@ export function resolveGroups(groupNames, regions, metadata) {
  *
  * Layer priority (highest to lowest):
  * 1. hidden - not rendered at all
- * 2. overlay - rendered above base
- * 3. underlay - rendered below base
- * 4. base - default layer for all other regions
+ * 2. annotation - rendered above hover/selection (always on top)
+ * 3. overlay - rendered above base but below selection/hover
+ * 4. underlay - rendered below base
+ * 5. base - default layer for all other regions
  *
  * A region appears in at most one layer.
  *
  * @param regions - The normalized regions map
  * @param underlay - Group names for underlay layer
  * @param overlay - Group names for overlay layer
+ * @param annotation - Group names for annotation layer (renders above hover)
  * @param hidden - Group names to hide
  * @param metadata - Optional outline metadata
  * @returns Layer assignment for each region
  */
-export function assignLayers(regions, underlay, overlay, hidden, metadata) {
+export function assignLayers(regions, underlay, overlay, annotation, hidden, metadata) {
     // Resolve group names to region IDs
     const underlayRegions = resolveGroups(underlay, regions, metadata);
     const overlayRegions = resolveGroups(overlay, regions, metadata);
+    const annotationRegions = resolveGroups(annotation, regions, metadata);
     const hiddenRegions = resolveGroups(hidden, regions, metadata);
     const result = {
         underlay: new Set(),
         base: new Set(),
         overlay: new Set(),
+        annotation: new Set(),
         hidden: new Set(),
     };
     // Assign each region to exactly one layer based on priority
     for (const id of Object.keys(regions)) {
         if (hiddenRegions.has(id)) {
             result.hidden.add(id);
+        }
+        else if (annotationRegions.has(id)) {
+            result.annotation.add(id);
         }
         else if (overlayRegions.has(id)) {
             result.overlay.add(id);

--- a/packages/shinymap/js/src/components/InputMap.tsx
+++ b/packages/shinymap/js/src/components/InputMap.tsx
@@ -83,6 +83,7 @@ export function InputMap(props: InputMapProps) {
   // Extract from nested layers config
   const underlays = layers?.underlay;
   const overlays = layers?.overlay;
+  const annotations = layers?.annotation;
   const hidden = layers?.hidden;
 
   // Extract from nested mode config (supports both string shorthand and full config)
@@ -97,8 +98,9 @@ export function InputMap(props: InputMapProps) {
 
   // New layer system: assign regions to layers
   const layerAssignment = useMemo(
-    () => assignLayers(normalizedRegions, underlays, overlays, hidden, outlineMetadata),
-    [normalizedRegions, underlays, overlays, hidden, outlineMetadata]
+    () =>
+      assignLayers(normalizedRegions, underlays, overlays, annotations, hidden, outlineMetadata),
+    [normalizedRegions, underlays, overlays, annotations, hidden, outlineMetadata]
   );
 
   const normalizedFillColor = useMemo(
@@ -497,6 +499,9 @@ export function InputMap(props: InputMapProps) {
             );
           })()}
       </g>
+
+      {/* Layer 6: Annotation - always on top, even above hover */}
+      <g>{renderNonInteractiveLayer(layerAssignment.annotation, "annotation")}</g>
     </svg>
   );
 }

--- a/packages/shinymap/js/src/components/OutputMap.tsx
+++ b/packages/shinymap/js/src/components/OutputMap.tsx
@@ -103,6 +103,7 @@ export function OutputMap(props: OutputMapProps) {
   // Extract from nested layers config
   const underlays = layers?.underlay;
   const overlays = layers?.overlay;
+  const annotations = layers?.annotation;
   const hidden = layers?.hidden;
 
   // Normalize regions to Element[] format (handles both v0.x strings and v1.x polymorphic elements)
@@ -110,8 +111,9 @@ export function OutputMap(props: OutputMapProps) {
 
   // New layer system: assign regions to layers
   const layerAssignment = useMemo(
-    () => assignLayers(normalizedRegions, underlays, overlays, hidden, outlineMetadata),
-    [normalizedRegions, underlays, overlays, hidden, outlineMetadata]
+    () =>
+      assignLayers(normalizedRegions, underlays, overlays, annotations, hidden, outlineMetadata),
+    [normalizedRegions, underlays, overlays, annotations, hidden, outlineMetadata]
   );
 
   const [hovered, setHovered] = useState<RegionId | null>(null);
@@ -464,6 +466,9 @@ export function OutputMap(props: OutputMapProps) {
             );
           })()}
       </g>
+
+      {/* Layer 6: Annotation - always on top, even above hover */}
+      <g>{renderNonInteractiveLayer(layerAssignment.annotation, "annotation")}</g>
     </svg>
   );
 }

--- a/packages/shinymap/js/src/types.ts
+++ b/packages/shinymap/js/src/types.ts
@@ -682,6 +682,8 @@ export type LayersConfig = {
   underlay?: string[];
   /** Group names to render in overlay layer (above base regions). */
   overlay?: string[];
+  /** Group names to render in annotation layer (above hover/selection, always on top). */
+  annotation?: string[];
   /** Group names to hide completely (not rendered). */
   hidden?: string[];
 };

--- a/packages/shinymap/python/examples/app_annotation.py
+++ b/packages/shinymap/python/examples/app_annotation.py
@@ -1,0 +1,110 @@
+"""Demo app for annotation layer feature (Issue #7).
+
+The annotation layer renders above hover/selection layers, ensuring
+text labels are always visible even when regions are hovered or selected.
+"""
+
+from shiny import App, render, ui
+
+from shinymap import Outline, aes, input_map, svg
+from shinymap.outline import Regions
+
+# Create an outline with shapes and text labels
+OUTLINE_WITH_LABELS = Outline(regions=Regions(
+    # Main interactive shapes
+    circle=[svg.Circle(cx=25, cy=70, r=20)],
+    square=[svg.Path(d="M10 10 H40 V40 H10 Z")],
+    triangle=[svg.Path(d="M75 70 L90 40 L60 40 Z")],
+    # Text labels (will be placed in annotation layer)
+    _label_circle=[
+        svg.Text(x=25, y=70, text="C", font_size=10, text_anchor="middle")
+    ],
+    _label_square=[
+        svg.Text(x=25, y=27, text="S", font_size=10, text_anchor="middle")
+    ],
+    _label_triangle=[
+        svg.Text(x=75, y=55, text="T", font_size=10, text_anchor="middle")
+    ]
+), metadata={"viewBox": "0 0 100 100"})
+
+
+# Move labels to annotation layer so they render above hover/selection
+LABELED_OUTLINE = OUTLINE_WITH_LABELS.move_layer(
+    "annotation", "_label_circle", "_label_square", "_label_triangle"
+)
+
+# For comparison: labels in overlay layer (will be hidden by hover/selection)
+OVERLAY_OUTLINE = OUTLINE_WITH_LABELS.move_layer(
+    "overlay", "_label_circle", "_label_square", "_label_triangle"
+)
+
+app_ui = ui.page_fixed(
+    ui.h2("Annotation Layer Demo"),
+    ui.p(
+        "The annotation layer renders above hover/selection layers. "
+        "Compare the two maps below - hover over the shapes to see the difference."
+    ),
+    ui.layout_columns(
+        ui.card(
+            ui.card_header("Labels in ANNOTATION Layer (Always Visible)"),
+            input_map(
+                "annotation_map",
+                LABELED_OUTLINE,
+                mode="multiple",
+                aes=aes.ByState(
+                    base=aes.Shape(fill_color="#e0f2fe", stroke_color="#0284c7"),
+                    select=aes.Shape(fill_color="#7dd3fc", stroke_color="#0369a1"),
+                    hover=aes.Shape(fill_opacity=0.8, stroke_width=2),
+                ),
+            ),
+            ui.output_text_verbatim("annotation_selected"),
+        ),
+        ui.card(
+            ui.card_header("Labels in OVERLAY Layer (Hidden by Hover)"),
+            input_map(
+                "overlay_map",
+                OVERLAY_OUTLINE,
+                mode="multiple",
+                aes=aes.ByState(
+                    base=aes.Shape(fill_color="#e0f2fe", stroke_color="#0284c7"),
+                    select=aes.Shape(fill_color="#7dd3fc", stroke_color="#0369a1"),
+                    hover=aes.Shape(fill_opacity=0.8, stroke_width=2),
+                ),
+            ),
+            ui.output_text_verbatim("overlay_selected"),
+        ),
+    ),
+    ui.h3("How it works"),
+    ui.pre(
+        ui.code(
+            """\
+from shinymap import Outline, svg
+from shinymap.outline import Regions
+
+# Create outline with text labels
+outline = Outline(regions=Regions(
+    circle=[svg.Circle(cx=25, cy=70, r=20)],
+    _label_circle=[svg.Text(x=25, y=70, text="C", font_size=10, text_anchor="middle")],
+    ...
+), metadata={"viewBox": "0 0 100 100"})
+
+# Move labels to annotation layer (above hover/selection)
+labeled = outline.move_layer("annotation", "_label_circle", ...)
+"""
+        )
+    ),
+    title="Annotation Layer Demo",
+)
+
+
+def server(input, output, session):
+    @render.text
+    def annotation_selected():
+        return f"Selected: {input.annotation_map()}"
+
+    @render.text
+    def overlay_selected():
+        return f"Selected: {input.overlay_map()}"
+
+
+app = App(app_ui, server)

--- a/packages/shinymap/python/src/shinymap/www/shinymap.global.js
+++ b/packages/shinymap/python/src/shinymap/www/shinymap.global.js
@@ -21937,19 +21937,23 @@ var shinymap = (() => {
     }
     return result;
   }
-  function assignLayers(regions, underlay, overlay, hidden, metadata) {
+  function assignLayers(regions, underlay, overlay, annotation, hidden, metadata) {
     const underlayRegions = resolveGroups(underlay, regions, metadata);
     const overlayRegions = resolveGroups(overlay, regions, metadata);
+    const annotationRegions = resolveGroups(annotation, regions, metadata);
     const hiddenRegions = resolveGroups(hidden, regions, metadata);
     const result = {
       underlay: /* @__PURE__ */ new Set(),
       base: /* @__PURE__ */ new Set(),
       overlay: /* @__PURE__ */ new Set(),
+      annotation: /* @__PURE__ */ new Set(),
       hidden: /* @__PURE__ */ new Set()
     };
     for (const id of Object.keys(regions)) {
       if (hiddenRegions.has(id)) {
         result.hidden.add(id);
+      } else if (annotationRegions.has(id)) {
+        result.annotation.add(id);
       } else if (overlayRegions.has(id)) {
         result.overlay.add(id);
       } else if (underlayRegions.has(id)) {
@@ -22137,6 +22141,7 @@ var shinymap = (() => {
     const aesGroup = isV03Format ? void 0 : legacyAes?.group;
     const underlays = layers?.underlay;
     const overlays = layers?.overlay;
+    const annotations = layers?.annotation;
     const hidden = layers?.hidden;
     const normalizedMode = typeof modeConfig === "string" ? { type: modeConfig } : modeConfig;
     const modeType = normalizedMode?.type ?? "multiple";
@@ -22145,8 +22150,8 @@ var shinymap = (() => {
     const aesIndexed = normalizedMode?.aesIndexed;
     const normalizedRegions = (0, import_react.useMemo)(() => normalizeRegions(regions), [regions]);
     const layerAssignment = (0, import_react.useMemo)(
-      () => assignLayers(normalizedRegions, underlays, overlays, hidden, outlineMetadata),
-      [normalizedRegions, underlays, overlays, hidden, outlineMetadata]
+      () => assignLayers(normalizedRegions, underlays, overlays, annotations, hidden, outlineMetadata),
+      [normalizedRegions, underlays, overlays, annotations, hidden, outlineMetadata]
     );
     const normalizedFillColor = (0, import_react.useMemo)(
       () => normalizeFillColor(fillColor, normalizedRegions),
@@ -22418,7 +22423,8 @@ var shinymap = (() => {
                 pointerEvents: "none"
               })
             );
-          })() })
+          })() }),
+          /* @__PURE__ */ (0, import_jsx_runtime2.jsx)("g", { children: renderNonInteractiveLayer(layerAssignment.annotation, "annotation") })
         ]
       }
     );
@@ -22478,11 +22484,12 @@ var shinymap = (() => {
     const aesBaseFillColorDict = typeof aesBaseRaw?.fillColor === "object" && aesBaseRaw.fillColor !== null ? aesBaseRaw.fillColor : void 0;
     const underlays = layers?.underlay;
     const overlays = layers?.overlay;
+    const annotations = layers?.annotation;
     const hidden = layers?.hidden;
     const normalizedRegions = (0, import_react2.useMemo)(() => normalizeRegions(regions), [regions]);
     const layerAssignment = (0, import_react2.useMemo)(
-      () => assignLayers(normalizedRegions, underlays, overlays, hidden, outlineMetadata),
-      [normalizedRegions, underlays, overlays, hidden, outlineMetadata]
+      () => assignLayers(normalizedRegions, underlays, overlays, annotations, hidden, outlineMetadata),
+      [normalizedRegions, underlays, overlays, annotations, hidden, outlineMetadata]
     );
     const [hovered, setHovered] = (0, import_react2.useState)(null);
     const activeSet = deriveActiveFromValue(value);
@@ -22724,7 +22731,8 @@ var shinymap = (() => {
                 pointerEvents: "none"
               })
             );
-          })() })
+          })() }),
+          /* @__PURE__ */ (0, import_jsx_runtime3.jsx)("g", { children: renderNonInteractiveLayer(layerAssignment.annotation, "annotation") })
         ]
       }
     );


### PR DESCRIPTION
## Summary

Add a new "annotation" layer that renders above hover/selection layers, ensuring text labels and other annotations always remain visible.

Closes #7

## Changes

**Files changed:**
- `layers.ts`: Add annotation to LayerAssignment type and assignLayers()
- `types.ts`: Add annotation to LayersConfig type
- `InputMap.tsx`: Add Layer 6 annotation rendering after hover layer
- `OutputMap.tsx`: Add Layer 6 annotation rendering after hover layer
- `_outline.py`: Add annotation_ids(), update layers_dict(), merge_layers(), move_layer()
- `app_annotation.py`: Demo app comparing annotation vs overlay layer behavior

**Rendering order** (SVG stacking - later = on top):
1. Underlay
2. Base (interactive)
3. Overlay
4. Selection layer
5. Hover layer
6. **Annotation layer** (new - always on top)

## Test plan

- [x] Run `make lint && make test` - all tests pass
- [ ] Manual test: Run `app_annotation.py` demo and verify annotation layer renders above hover/selection

🤖 Generated with [Claude Code](https://claude.com/claude-code)